### PR TITLE
Add support for symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "symfony/ux-twig-component": "^2.31",
-        "symfony/twig-bundle": "^7.4",
+        "symfony/twig-bundle": "^7.4|^8.0",
         "symfony/stimulus-bundle": "^2.0"
     },
     "extra": {


### PR DESCRIPTION
This pull request updates the `composer.json` file to allow compatibility with a newer major version of a Symfony package.

Dependency compatibility update:

* Expanded the version constraint for `symfony/twig-bundle` to support both `^7.4` and `^8.0`, enabling compatibility with Symfony 8.x as well as 7.x.

ref: #1 